### PR TITLE
Use cryptography's built-in PKCS7 padding functions

### DIFF
--- a/src/common/statics.py
+++ b/src/common/statics.py
@@ -517,6 +517,7 @@ BLAKE2_DIGEST_LENGTH_MAX         = 64
 ENTROPY_THRESHOLD                = 512
 HARAC_LENGTH                     = 8
 PADDING_LENGTH                   = 255
+PADDING_LENGTH_BITS              = PADDING_LENGTH * 8
 
 # Forward secrecy
 INITIAL_HARAC        = 0


### PR DESCRIPTION
Using cryptography's built-in padding functions is more readable than manually appending / removing the bytes.

I've tested the changes:

![Screenshot](https://user-images.githubusercontent.com/6752449/56369239-2d021780-6223-11e9-94bd-3a67d2dfb276.png)

I assign all copyright for the changes to you :)